### PR TITLE
Add cursor pointer when hovering menu buttons

### DIFF
--- a/js/canvasmenu.js
+++ b/js/canvasmenu.js
@@ -325,6 +325,19 @@ Button.prototype.inRange = function (x, y) {
 };
 
 Button.prototype.setState = function (newState) {
+	var menuCanvas = this.menu.canvas;
+
+	// If the button state is changed to 'focused', when means
+	// the button is in the 'hover' state...
+	if (newState === BUTTON_ENUM.focused) {
+		// ...change the mouse cursor to 'pointer' so it behaves as
+		// a regular link.
+		menuCanvas.style.cursor = 'pointer';
+	} else {
+		// If it's not, switch the cursor to the regular state.
+		menuCanvas.style.cursor = '';
+	}
+
 	this.state = newState;
 	this.tick = 0;
 };


### PR DESCRIPTION
This patch adds a `cursor:pointer` support for buttons on mouse over, adding a proper css style to the whole canvas for the time when buttons are switching from `inactive` to the `focused` state. 
![screen-2015 12 27 13 22 03](https://cloud.githubusercontent.com/assets/347657/12010190/1eb07788-ac9d-11e5-9a3c-e1744de1b6e3.png)
When the cursor move outside the button, the previous state is restored
![screen-2015 12 27 13 22 37](https://cloud.githubusercontent.com/assets/347657/12010192/38bdffe2-ac9d-11e5-81e7-9d858b399743.png)
