### PR TITLE
[Closing #14] - create with componentType argument instead of create …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 node_modules/
+.fancom

--- a/js/canvasmenu.js
+++ b/js/canvasmenu.js
@@ -149,7 +149,7 @@ CM.Menu = function(config) {
 			window.requestAnimationFrame(self.run);
 		}
 	};
-}
+};
 
 CM.Menu.prototype.isVisible = function () {
 	return this.running;
@@ -395,8 +395,8 @@ CM.Button.prototype.trigger = function (eventType, event) {
 
 CM.Button.prototype.on = function (eventType, handler) {
     if (!(eventType in this.events)) {
-        throw new Error("Wrong Event! This library only allows for triggering the following events: "
-            + Object.keys(this.events));
+        throw new Error("Wrong Event! This library only allows for triggering the following events: " +
+				Object.keys(this.events));
     } else {
         if (eventType === 'click' && handler instanceof CM.Menu) {
             var i;
@@ -411,8 +411,14 @@ CM.Button.prototype.on = function (eventType, handler) {
     }
 };
 
-CM.Menu.prototype.createButton = function (config) {
-    var button = new CM.Button(config);
-    this.add(button);
-    return button;
+CM.Menu.prototype.create = function (componentType, config) {
+	// capitalize the type of the component, so 'button' will became 'Button'
+	componentType = componentType.charAt(0).toUpperCase() + componentType.slice(1);
+	if (CM[componentType]){
+		var component = new CM[componentType](config);
+		this.add(component);
+		return component;
+	} else {
+		throw new Error("Component of " + componentType + " type not found");
+	}
 };

--- a/samples/1/config.js
+++ b/samples/1/config.js
@@ -16,7 +16,7 @@ var x = 20, // px
     buttonHeight = 50, // px
     buttonText = "Test text";
 
-myMenu.createButton({
+myMenu.create('button', {
     x: x,
     y: y,
     width: buttonWidth,

--- a/samples/2/config.js
+++ b/samples/2/config.js
@@ -16,7 +16,7 @@ var mainMenu = new CM.Menu(menuConfig),
 var buttonWidth = 400, // px
     buttonHeight = 50; // px
 
-var newGameButton = mainMenu.createButton({
+var newGameButton = mainMenu.create('button', {
     x: 200,
     y: 280,
     width: buttonWidth,
@@ -24,14 +24,14 @@ var newGameButton = mainMenu.createButton({
     text: "New Game"
 });
 //That's what we'll be looping
-var optionsButton = mainMenu.createButton({
+var optionsButton = mainMenu.create('button', {
     x: 200,
     y: 280 + buttonHeight + 10,
     width: buttonWidth,
     height: buttonHeight,
     text: "Options"
 });
-var exitButton = mainMenu.createButton({
+var exitButton = mainMenu.create('button', {
     x: 200,
     y: 280 + 2 * (buttonHeight + 10),
     width: buttonWidth,
@@ -47,14 +47,14 @@ exitButton.on('click', function () {
 });
 optionsButton.on('click', optionsMenu);
 
-var infoButton = optionsMenu.createButton({
+var infoButton = optionsMenu.create('button', {
     x: 200,
     y: 280,
     width: buttonWidth,
     height: buttonHeight,
     text: "Information"
 });
-var mainMenuButton = optionsMenu.createButton({
+var mainMenuButton = optionsMenu.create('button', {
     x: 200,
     y: 280 + 2 * (buttonHeight + 10),
     width: buttonWidth,

--- a/samples/3/config.js
+++ b/samples/3/config.js
@@ -15,7 +15,7 @@ var mainMenu = new CM.Menu(menuConfig);
 var buttonWidth = 400, // px
     buttonHeight = 50; // px
 
-var newGameButton = mainMenu.createButton({
+var newGameButton = mainMenu.create('button', {
     x: 200,
     y: 280,
     width: buttonWidth,
@@ -37,7 +37,7 @@ var newGameButton = mainMenu.createButton({
     },
     font: (buttonHeight * 2 / 5 ) + 'pt Courier' //I want it smaller
 });
-var optionsButton = mainMenu.createButton({
+var optionsButton = mainMenu.create('button', {
     x: 200,
     y: 280 + buttonHeight + 10,
     width: buttonWidth,
@@ -59,7 +59,7 @@ var optionsButton = mainMenu.createButton({
     },
     font: (buttonHeight * 2 / 5 ) + 'pt Courier' //I want it smaller
 });
-var exitButton = mainMenu.createButton({
+var exitButton = mainMenu.create('button', {
     x: 200,
     y: 280 + 2 * (buttonHeight + 10),
     width: buttonWidth,

--- a/samples/4/config.js
+++ b/samples/4/config.js
@@ -210,7 +210,7 @@ var RedrawFocusedButton = function () {
 };
 
 
-var newGameButton = mainMenu.createButton({
+var newGameButton = mainMenu.create('button', {
     x: 200,
     y: 280,
     width: buttonWidth,
@@ -232,7 +232,7 @@ var newGameButton = mainMenu.createButton({
     },
     font: (buttonHeight * 2 / 5 ) + 'pt Courier' //I want it smaller
 });
-var optionsButton = mainMenu.createButton({
+var optionsButton = mainMenu.create('button', {
     x: 200,
     y: 280 + buttonHeight + 10,
     width: buttonWidth,
@@ -254,7 +254,7 @@ var optionsButton = mainMenu.createButton({
     },
     font: (buttonHeight * 2 / 5 ) + 'pt Courier'
 });
-var exitButton = mainMenu.createButton({
+var exitButton = mainMenu.create('button', {
     x: 200,
     y: 280 + 2 * (buttonHeight + 10),
     width: buttonWidth,

--- a/samples/5/config.js
+++ b/samples/5/config.js
@@ -254,7 +254,7 @@ var RedrawFocusedButton = function () {
 };
 
 
-var newGameButton = mainMenu.createButton({
+var newGameButton = mainMenu.create('button', {
     x: 200,
     y: 280,
     width: buttonWidth,
@@ -276,7 +276,7 @@ var newGameButton = mainMenu.createButton({
     },
     font: (buttonHeight * 2 / 5 ) + 'pt Courier' //I want it smaller
 });
-var optionsButton = mainMenu.createButton({
+var optionsButton = mainMenu.create('button', {
     x: 200,
     y: 280 + buttonHeight + 10,
     width: buttonWidth,
@@ -298,7 +298,7 @@ var optionsButton = mainMenu.createButton({
     },
     font: (buttonHeight * 2 / 5 ) + 'pt Courier'
 });
-var exitButton = mainMenu.createButton({
+var exitButton = mainMenu.create('button', {
     x: 200,
     y: 280 + 2 * (buttonHeight + 10),
     width: buttonWidth,

--- a/samples/mysample/config.js
+++ b/samples/mysample/config.js
@@ -80,7 +80,7 @@ var redrawInactive = function (ctx) {
 };
 
 //Button creation + click binding
-var newGameMainMenuButton = mainMenu.createButton({
+var newGameMainMenuButton = mainMenu.create('button', {
     x: width / 2 - buttonWidth / 2,
     y: 270,
     width: buttonWidth,
@@ -92,7 +92,7 @@ var newGameMainMenuButton = mainMenu.createButton({
 });
 newGameMainMenuButton.on('click', newGameMenu);
 
-var optionsMainMenuButton = mainMenu.createButton({
+var optionsMainMenuButton = mainMenu.create('button', {
     x: width / 2 - buttonWidth / 2,
     y: 270 + buttonHeight + 20,
     width: buttonWidth,
@@ -113,7 +113,7 @@ var optionsMainMenuButton = mainMenu.createButton({
 });
 optionsMainMenuButton.on('click', optionsMenu);
 
-var aboutMainMenuButton = mainMenu.createButton({
+var aboutMainMenuButton = mainMenu.create('button', {
     x: width / 2 - buttonWidth / 2,
     y: 270 + 2 * (buttonHeight + 20),
     width: buttonWidth,
@@ -121,7 +121,7 @@ var aboutMainMenuButton = mainMenu.createButton({
     text: "About"});
 aboutMainMenuButton.on('click', aboutMenu);
 
-var backOptionsButton = newGameMenu.createButton({
+var backOptionsButton = newGameMenu.create('button', {
     x: 10,
     y: height - 60,
     width: buttonHeight,
@@ -130,7 +130,7 @@ var backOptionsButton = newGameMenu.createButton({
 });
 backOptionsButton.on('click', mainMenu);
 
-var backNewGameButton = optionsMenu.createButton({
+var backNewGameButton = optionsMenu.create('button', {
     x: 10,
     y: height - 60,
     width: buttonHeight,
@@ -139,7 +139,7 @@ var backNewGameButton = optionsMenu.createButton({
 });
 backNewGameButton.on('click', mainMenu);
 
-var backAboutButton = aboutMenu.createButton({
+var backAboutButton = aboutMenu.create('button', {
     x: 10,
     y: height - 60,
     width: buttonHeight,

--- a/samples/scale/config.js
+++ b/samples/scale/config.js
@@ -254,7 +254,7 @@ var RedrawFocusedButton = function () {
 };
 
 
-var newGameButton = mainMenu.createButton({
+var newGameButton = mainMenu.create('button', {
     x: 200,
     y: 280,
     width: buttonWidth,
@@ -276,7 +276,7 @@ var newGameButton = mainMenu.createButton({
     },
     font: (buttonHeight * 2 / 5 ) + 'pt Courier' //I want it smaller
 });
-var optionsButton = mainMenu.createButton({
+var optionsButton = mainMenu.create('button', {
     x: 200,
     y: 280 + buttonHeight + 10,
     width: buttonWidth,
@@ -298,7 +298,7 @@ var optionsButton = mainMenu.createButton({
     },
     font: (buttonHeight * 2 / 5 ) + 'pt Courier'
 });
-var exitButton = mainMenu.createButton({
+var exitButton = mainMenu.create('button', {
     x: 200,
     y: 280 + 2 * (buttonHeight + 10),
     width: buttonWidth,


### PR DESCRIPTION
…button

This patch uses `create('button', {})` in place of `createButton` method. This solution will be more generic for multiple components.
